### PR TITLE
Fix AttributeGraph warnings

### DIFF
--- a/Sources/ASCollectionView/Datasource/ASDiffableDataSourceCollectionView.swift
+++ b/Sources/ASCollectionView/Datasource/ASDiffableDataSourceCollectionView.swift
@@ -40,18 +40,15 @@ class ASDiffableDataSourceCollectionView<SectionID: Hashable>: ASDiffableDataSou
 				self.currentSnapshot = .init(sections: newSections)
 			}
 		}
-		CATransaction.begin()
-		CATransaction.setCompletionBlock(completion)
 		if firstLoad || !animated
 		{
-			CATransaction.setDisableActions(true)
-			apply()
+		        UIView.performWithoutAnimation(apply)
 		}
 		else
 		{
 			apply()
 		}
-		CATransaction.commit()
+                completion?()
 		firstLoad = false
 	}
 


### PR DESCRIPTION
When using ASCollectionView with an @ObservedObject for the data source of it

s sections *and* also having it embedded into an existing UIKit view controller AttributeGraph complains of some cycles.

This was narrowed down to how a nested CATransaction is utilised to prevent animation during updates.

A sample project exhibiting the bug (and fix) can be downloaded here [Uploading ASCollectionView.zip…]()